### PR TITLE
Fix team schema

### DIFF
--- a/client/src/components/TeamForm.tsx
+++ b/client/src/components/TeamForm.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { FormValues } from '../types';
 import { createTeamRequest, deleteTeamRequest, getTeamRequest, updateTeamRequest } from '../services/api';
 import { createTeamSchema, updateTeamSchema } from '../schemas/team.schema';
+import { countries } from '../utils/constants';
 
 const INITIAL_VALUES: FormValues = {
   name: '',
@@ -147,72 +148,13 @@ export function TeamForm() {
                 id="area.name"
                 name="area[name]"
                 className="bg-gray-50 border border-gray-300 text-gray-800 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  setFieldValue('area[name]', e.target.value);
-                }}
               >
                 <option value="country">Select country</option>
-                <option value="Africa">Africa</option>
-                <option value="Argentina">Argentina</option>
-                <option value="Asia">Asia</option>
-                <option value="Australia">Australia</option>
-                <option value="Austria">Austria</option>
-                <option value="Belgium">Belgium</option>
-                <option value="Bolivia">Bolivia</option>
-                <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
-                <option value="Brazil">Brazil</option>
-                <option value="Bulgaria">Bulgaria</option>
-                <option value="Canada">Canada</option>
-                <option value="Chile">Chile</option>
-                <option value="China">China</option>
-                <option value="Colombia">Colombia</option>
-                <option value="Croatia">Croatia</option>
-                <option value="Czech Republic">Czech Republic</option>
-                <option value="Denmark">Denmark</option>
-                <option value="Ecuador">Ecuador</option>
-                <option value="England">England</option>
-                <option value="Estonia">Estonia</option>
-                <option value="Europe">Europe</option>
-                <option value="Finland">Finland</option>
-                <option value="France">France</option>
-                <option value="Germany">Germany</option>
-                <option value="Greece">Greece</option>
-                <option value="Hungary">Hungary</option>
-                <option value="Iceland">Iceland</option>
-                <option value="India">India</option>
-                <option value="Israel">Israel</option>
-                <option value="Italy">Italy</option>
-                <option value="Japan">Japan</option>
-                <option value="Latvia">Latvia</option>
-                <option value="Lithuania">Lithuania</option>
-                <option value="Malta">Malta</option>
-                <option value="Mexico">Mexico</option>
-                <option value="Netherlands">Netherlands</option>
-                <option value="North Ireland">North Ireland</option>
-                <option value="Norway">Norway</option>
-                <option value="Oceania">Oceania</option>
-                <option value="Panama">Panama</option>
-                <option value="Paraguay">Paraguay</option>
-                <option value="Peru">Peru</option>
-                <option value="Poland">Poland</option>
-                <option value="Portugal">Portugal</option>
-                <option value="Republic of Ireland">Republic of Ireland</option>
-                <option value="Romania">Romania</option>
-                <option value="Russian Federation">Russian Federation</option>
-                <option value="Scotland">Scotland</option>
-                <option value="South Africa">South Africa</option>
-                <option value="South America">South America</option>
-                <option value="Spain">Spain</option>
-                <option value="Sweden">Sweden</option>
-                <option value="Switzerland">Switzerland</option>
-                <option value="Turkey">Turkey</option>
-                <option value="Ukraine">Ukraine</option>
-                <option value="United States">United States</option>
-                <option value="Uruguay">Uruguay</option>
-                <option value="Venezuela">Venezuela</option>
-                <option value="Vietnam">Vietnam</option>
-                <option value="Wales">Wales</option>
-                <option value="World">World</option>
+                {countries.map((country) => (
+                  <option key={country.id} value={country.name}>
+                    {country.name}
+                  </option>
+                ))}
               </Field>
               <ErrorMessage
                 name="area[name]"
@@ -361,6 +303,7 @@ export function TeamForm() {
                 accept=".png, .jpg, .jpeg, .svg"
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const files = e.target.files;
+                  console.log(files);
                   setFieldValue('crestUrl', URL.createObjectURL(files?.item(0) as Blob));
                 }}
               />

--- a/client/src/schemas/team.schema.ts
+++ b/client/src/schemas/team.schema.ts
@@ -115,15 +115,17 @@ export const updateTeamSchema = yup.object({
     .trim()
     .matches(addressRegex, { message: 'Address should be a valid address' })
     .min(7, 'must be at least 7 characters long')
-    .max(50, 'must be a maximum of 50 characters'),
+    .max(50, 'must be a maximum of 50 characters')
+    .nullable(),
   phone: yup
     .string()
     .trim()
     .matches(phoneRegex, { message: 'should be a valid phone number' })
     .min(10, 'must be at least 10 characters long')
-    .max(30, 'must be a maximum of 30 characters'),
-  website: yup.string().trim().matches(websiteRegex, { message: 'should be a URL' }).url('should be a URL'),
-  email: yup.string().trim().matches(emailRegex, { message: 'Please provide valid email' }),
+    .max(30, 'must be a maximum of 30 characters')
+    .nullable(),
+  website: yup.string().trim().matches(websiteRegex, { message: 'should be a URL' }).url('should be a URL').nullable(),
+  email: yup.string().trim().matches(emailRegex, { message: 'Please provide valid email' }).nullable(),
   founded: yup
     .number()
     .lessThan(todayDate.getUTCFullYear(), 'must not exceed current year')
@@ -135,5 +137,6 @@ export const updateTeamSchema = yup.object({
     .trim()
     .matches(venueRegex, { message: "should only contain alphanumeric, spaces and the next symbol: '-'" })
     .min(7, 'must be at least 7 characters long')
-    .max(40, 'must be a maximum of 40 characters'),
+    .max(40, 'must be a maximum of 40 characters')
+    .nullable(),
 });

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -1,0 +1,246 @@
+export const countries = [
+  {
+    name: 'Africa',
+    id: 2001,
+  },
+  {
+    name: 'Argentina',
+    id: 2011,
+  },
+  {
+    name: 'Asia',
+    id: 2014,
+  },
+  {
+    name: 'Australia',
+    id: 2015,
+  },
+  {
+    name: 'Austria',
+    id: 2016,
+  },
+  {
+    name: 'Belgium',
+    id: 2023,
+  },
+  {
+    name: 'Bolivia',
+    id: 2028,
+  },
+  {
+    name: 'Bosnia and Herzegovina',
+    id: 2030,
+  },
+  {
+    name: 'Brazil',
+    id: 2032,
+  },
+  {
+    name: 'Bulgaria',
+    id: 2035,
+  },
+  {
+    name: 'Canada',
+    id: 2040,
+  },
+  {
+    name: 'Chile',
+    id: 2041,
+  },
+  {
+    name: 'China',
+    id: 2046,
+  },
+  {
+    name: 'Colombia',
+    id: 2049,
+  },
+  {
+    name: 'Croatia',
+    id: 2058,
+  },
+  {
+    name: 'Czech Republic',
+    id: 2062,
+  },
+  {
+    name: 'Denmark',
+    id: 2065,
+  },
+  {
+    name: 'Ecuador',
+    id: 2069,
+  },
+  {
+    name: 'England',
+    id: 2072,
+  },
+  {
+    name: 'Estonia',
+    id: 2075,
+  },
+  {
+    name: 'Europe',
+    id: 2077,
+  },
+  {
+    name: 'Finland',
+    id: 2080,
+  },
+  {
+    name: 'France',
+    id: 2081,
+  },
+  {
+    name: 'Germany',
+    id: 2088,
+  },
+  {
+    name: 'Greece',
+    id: 2093,
+  },
+  {
+    name: 'Hungary',
+    id: 2106,
+  },
+  {
+    name: 'Iceland',
+    id: 2107,
+  },
+  {
+    name: 'India',
+    id: 2108,
+  },
+  {
+    name: 'Israel',
+    id: 2113,
+  },
+  {
+    name: 'Italy',
+    id: 2114,
+  },
+  {
+    name: 'Japan',
+    id: 2116,
+  },
+  {
+    name: 'Latvia',
+    id: 2129,
+  },
+  {
+    name: 'Lithuania',
+    id: 2135,
+  },
+  {
+    name: 'Malta',
+    id: 2143,
+  },
+  {
+    name: 'Mexico',
+    id: 2149,
+  },
+  {
+    name: 'Netherlands',
+    id: 2163,
+  },
+  {
+    name: 'Northern Ireland',
+    id: 2171,
+  },
+  {
+    name: 'Norway',
+    id: 2173,
+  },
+  {
+    name: 'Oceania',
+    id: 2175,
+  },
+  {
+    name: 'Panama',
+    id: 2181,
+  },
+  {
+    name: 'Paraguay',
+    id: 2182,
+  },
+  {
+    name: 'Peru',
+    id: 2184,
+  },
+  {
+    name: 'Poland',
+    id: 2186,
+  },
+  {
+    name: 'Portugal',
+    id: 2187,
+  },
+  {
+    name: 'Republic of Ireland',
+    id: 2192,
+  },
+  {
+    name: 'Romania',
+    id: 2193,
+  },
+  {
+    name: 'Russian Federation',
+    id: 2194,
+  },
+  {
+    name: 'Scotland',
+    id: 2204,
+  },
+  {
+    name: 'South Africa',
+    id: 2219,
+  },
+  {
+    name: 'South America',
+    id: 2220,
+  },
+  {
+    name: 'Spain',
+    id: 2224,
+  },
+  {
+    name: 'Sweden',
+    id: 2233,
+  },
+  {
+    name: 'Switzerland',
+    id: 2234,
+  },
+  {
+    name: 'Turkey',
+    id: 2247,
+  },
+  {
+    name: 'Ukraine',
+    id: 2253,
+  },
+  {
+    name: 'United States',
+    id: 2256,
+  },
+  {
+    name: 'Uruguay',
+    id: 2257,
+  },
+  {
+    name: 'Venezuela',
+    id: 2262,
+  },
+  {
+    name: 'Vietnam',
+    id: 2263,
+  },
+  {
+    name: 'Wales',
+    id: 2264,
+  },
+  {
+    name: 'World',
+    id: 2267,
+  },
+];


### PR DESCRIPTION
The non-mandatory fields can be left empty when the team is updated, the input=select options are visually modified.}